### PR TITLE
Enable passing HTTPContext through HttpOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebenefitsbv/odata-v4-ng",
-  "version": "19.0.2",
+  "version": "19.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebenefitsbv/odata-v4-ng",
-      "version": "19.0.2",
+      "version": "19.0.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^19.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebenefitsbv/odata-v4-ng",
-  "version": "19.0.3",
+  "version": "19.0.2",
   "license": "MIT",
   "description": "Client side OData V4 typescript library for Angular, continuance on the version originally built by Riccardo Mariani",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "tag-package-version": "npm version 19.0.2 --allow-same-version --git-tag-version && node scripts/align-package-version-number.js",
+    "tag-package-version": "npm version 19.0.3 --allow-same-version --git-tag-version && node scripts/align-package-version-number.js",
     "buildLib": "ncp README.md projects/odata-v4-ng/README.md && ng lint odata-v4-ng && ng test odata-v4-ng && ng build odata-v4-ng --configuration=production",
     "buildApp": "ng lint odata-v4-ng-app && ng test odata-v4-ng-app && ng build odata-v4-ng-app --configuration=production && rimraf docs && move-cli dist/odata-v4-ng-app docs",
     "buildAll": "npm run buildLib && npm run buildApp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebenefitsbv/odata-v4-ng",
-  "version": "19.0.2",
+  "version": "19.0.3",
   "license": "MIT",
   "description": "Client side OData V4 typescript library for Angular, continuance on the version originally built by Riccardo Mariani",
   "repository": {

--- a/projects/odata-v4-ng/package.json
+++ b/projects/odata-v4-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebenefitsbv/odata-v4-ng",
-  "version": "19.0.3",
+  "version": "19.0.2",
   "license": "MIT",
   "description": "Client side OData V4 typescript library for Angular, continuance on the version originally built by Riccardo Mariani",
   "repository": {

--- a/projects/odata-v4-ng/package.json
+++ b/projects/odata-v4-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebenefitsbv/odata-v4-ng",
-  "version": "19.0.2",
+  "version": "19.0.3",
   "license": "MIT",
   "description": "Client side OData V4 typescript library for Angular, continuance on the version originally built by Riccardo Mariani",
   "repository": {

--- a/projects/odata-v4-ng/src/lib/odata-service/http-options.spec.ts
+++ b/projects/odata-v4-ng/src/lib/odata-service/http-options.spec.ts
@@ -35,6 +35,7 @@ describe('HttpOptions', () => {
       new HttpHeaders({ test: 'test' }),
       'response',
       new HttpParams({ fromString: 'test=test' }),
+      undefined,
       true,
       'text',
       true

--- a/projects/odata-v4-ng/src/lib/odata-service/http-options.ts
+++ b/projects/odata-v4-ng/src/lib/odata-service/http-options.ts
@@ -1,10 +1,11 @@
-import { HttpHeaders, HttpParams } from '@angular/common/http';
+import {HttpContext, HttpHeaders, HttpParams} from '@angular/common/http';
 
 export interface HttpOptionsI {
     headers?: HttpHeaders;
     params?: HttpParams;
     reportProgress?: boolean;
     withCredentials?: boolean;
+    context?: HttpContext;
 }
 
 export class HttpOptions implements HttpOptionsI {
@@ -12,8 +13,9 @@ export class HttpOptions implements HttpOptionsI {
         public headers?: HttpHeaders,
         public observe: 'response' = 'response',
         public params?: HttpParams,
+        public context?: HttpContext,
         public reportProgress?: boolean,
         public responseType: 'text' = 'text',
-        public withCredentials?: boolean
+        public withCredentials?: boolean,
     ) { }
 }

--- a/projects/odata-v4-ng/src/lib/odata-service/odata.service.spec.ts
+++ b/projects/odata-v4-ng/src/lib/odata-service/odata.service.spec.ts
@@ -23,12 +23,14 @@ describe('OdataService', () => {
     'response',
     undefined,
     undefined,
+    undefined,
     'text',
     undefined
   );
   const HTTP_OPTIONS_I_RES_ETAG: HttpOptions = new HttpOptions(
     new HttpHeaders({ header: 'value', etag: 'etag' }),
     'response',
+    undefined,
     undefined,
     undefined,
     'text',
@@ -40,10 +42,12 @@ describe('OdataService', () => {
     undefined,
     undefined,
     undefined,
+    undefined,
     undefined
   );
   const HTTP_OPTIONS_ETAG: HttpOptions = new HttpOptions(
     new HttpHeaders({ etag: 'etag' }),
+    undefined,
     undefined,
     undefined,
     undefined,


### PR DESCRIPTION
We are already able to pass Headers and Params, but now we also enable passing HttpContext, as this is something that might be need with HTTP requests in angular. (VIEB-21222)